### PR TITLE
Feature/"Add-ons" to properties panel

### DIFF
--- a/build/dev/properties.js
+++ b/build/dev/properties.js
@@ -617,7 +617,15 @@ define( [
 					bookmark2: bookmark2,
 					softlock2: softlock2
 				}
-			}
+			},
+			addons: {  
+				uses: "addons",  
+				items: {  
+					dataHandling: {  
+						uses: "dataHandling"  
+					}  
+				}  
+			} 
 		}
 	};
 


### PR DESCRIPTION
Allowing hide feature when expressions are used: eg. COUNT(DISTINCT OrderNumber) =1

Code referenced from [here](https://community.qlik.com/thread/177689) with warning "not officially supported so this might break in the future".